### PR TITLE
Dynamic Mask

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -24,6 +24,14 @@
 	<input id="tel" type="text" placeholder="telefone">
 	<input id="doc" type="text" placeholder="documento">
 
+	<fieldset>
+		<select id="tipo">
+			<option selected>BRL</option>
+			<option>USD</option>
+		</select>
+		<input id="valor" type="text" placeholder="valor" data-mask="9 999,99" value="123456">
+	</fieldset>
+
 	<script type="module">
 		import Mask from '../src/mask.js'
 
@@ -48,6 +56,16 @@
 			},
 			triggerOnDelete: true
 		});
+
+
+		// change data-mask on the fly
+		const placaMask = new Mask(valor, {
+			dynamicDataMask: true,
+			init: true,
+		});
+		tipo.onchange = (e) => {
+			valor.dataset.mask = tipo.value === 'BRL' ? "9 999,99" : "9,999.99"
+		}
 	</script>
 </body>
 

--- a/example/index.html
+++ b/example/index.html
@@ -45,7 +45,8 @@
 					return "99.999.999/9999-99"
 				}
 				return "999.999.999-999"
-			}
+			},
+			triggerOnDelete: true
 		});
 	</script>
 </body>

--- a/example/index.html
+++ b/example/index.html
@@ -1,16 +1,53 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="width=device-width, user-scalable=no">
-		<title>Example</title>
-	</head>
-	<body>
-		<input id="telefone" type="text" data-mask="(99) 9-9999-9999">
-		<script type="module">
-			import Mask from '../src/mask.js'
-			const mask = new Mask(telefone)
-		</script>
-	</body>
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<title>Example</title>
+	<style>
+		body {
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+		}
+
+		fieldset input {
+			margin-left: auto
+		}
+	</style>
+</head>
+
+<body>
+	<input id="cep" type="text" placeholder="CEP" data-mask="99999-999">
+	<input id="tel" type="text" placeholder="telefone">
+	<input id="doc" type="text" placeholder="documento">
+
+	<script type="module">
+		import Mask from '../src/mask.js'
+
+		// static mask using data-attribute
+		const cepMask = new Mask(cep);
+
+
+		// static mask using string mask option
+		const telMask = new Mask(tel, {
+			mask: "(99) 9 9999-9999",
+			init: true,
+		});
+
+
+		// dynamic mask, passing function as mask option
+		const docMask = new Mask(doc, {
+			mask: (inp) => {
+				if (inp.value.replace(/\D/g, '').length > 11) {
+					return "99.999.999/9999-99"
+				}
+				return "999.999.999-999"
+			}
+		});
+	</script>
+</body>
+
 </html>

--- a/src/mask.js
+++ b/src/mask.js
@@ -31,7 +31,7 @@ class Mask {
 	 * Mascara um valor
 	 * @param {string|number} _value - valor
 	 * @param {string} _mask - formato da máscara
-	 * @return {string} Retorna o valor mascaradi
+	 * @return {string} Retorna o valor mascarado
 	 * @memberof Mask
 	 * @static
 	 */
@@ -81,7 +81,10 @@ class Mask {
 
 		this.events = new Set()
 		this.input = input
-		this.mask = input.dataset?.mask ?? this.opts.mask
+
+		this.mask = input.dataset.mask ?? (
+			typeof this.opts.mask === 'function' ? this.opts.mask(input) : this.opts.mask
+		)
 
 		// Check if has mask
 		if (this.mask.length === 0) {
@@ -90,7 +93,7 @@ class Mask {
 
 		// Initialize
 		if (this.opts.init) {
-			this.input.value = Mask.masking(this.input.value, this.mask)
+			this.masking()
 		}
 
 		// Listener
@@ -113,6 +116,10 @@ class Mask {
 			return false
 		}
 
+		if (typeof this.opts.mask === 'function') {
+			this.mask = this.opts.mask(this.input, event)
+		}
+
 		this.input.value = Mask.masking(this.input.value, this.mask)
 	}
 
@@ -126,6 +133,9 @@ class Mask {
 		}
 	}
 
+	/**
+	 * @param {Event} event
+	 * */
 	handleEvent(event) {
 		this.masking(event)
 	}

--- a/src/mask.js
+++ b/src/mask.js
@@ -75,6 +75,7 @@ class Mask {
 	 * @typedef {{
 	 * 	keyEvent: keyof HTMLElementEventMap,
 	 * 	triggerOnBlur: Boolean,
+	 * 	triggerOnDelete: Boolean,
 	 * 	init: Boolean,
 	 * 	mask: string | DynamicMask | undefined
 	 * }} Opts
@@ -95,6 +96,7 @@ class Mask {
 		this.opts = {
 			keyEvent: 'input',
 			triggerOnBlur: false,
+			triggerOnDelete: false, // default to false for backward compatibility
 			init: false,
 			mask: undefined,
 			...opts,
@@ -167,11 +169,6 @@ class Mask {
 	 * @param {InputEvent} [event]
 	 * */
 	masking(event) {
-		/* istanbul ignore next */
-		if (event && event.inputType === 'deleteContentBackward') {
-			return false
-		}
-
 		this.#evaluateMask(event)
 		this.input.value = Mask.masking(this.input.value, this.mask)
 	}
@@ -190,6 +187,11 @@ class Mask {
 	 * @param {InputEvent} event
 	 * */
 	handleEvent(event) {
+		/* istanbul ignore next */
+		if (!this.opts.triggerOnDelete && (event.inputType === 'deleteContentBackward' || event.inputType === 'deleteContentForward')) {
+			return false
+		}
+
 		this.masking(event)
 	}
 }

--- a/src/mask.js
+++ b/src/mask.js
@@ -97,14 +97,9 @@ class Mask {
 		// satityze user's opts
 		for (const key of Object.keys(opts)) {
 			if (opts[key] === null || opts[key] === undefined) {
-				delete opts[key]
+				continue
 			}
-		}
-
-		/** @type {Opts} */
-		this.opts = {
-			...this.opts,
-			...opts,
+			this.opts[key] = opts[key]
 		}
 
 		if (input instanceof globalThis.HTMLInputElement === false) {

--- a/src/mask.js
+++ b/src/mask.js
@@ -61,7 +61,6 @@ class Mask {
 	}
 
 	/**
-	 *
 	 * @typedef {(input: HTMLInputElement, event?: Event)=>string} DynamicMask
 	 * - A function that returns the mask string on the fly.
 	 * It runs on each event, to evaluate new mask before applying it.
@@ -80,10 +79,20 @@ class Mask {
 	 * 	mask: string | DynamicMask | undefined
 	 * }} Opts
 	 *
-	 *
-	 * @param {HTMLInputElement} input
-	 * @param {Partial<Opts>} opts
-	 * */
+	 * @type {Opts}
+	 */
+	opts = {
+		keyEvent: 'input',
+		triggerOnBlur: false,
+		triggerOnDelete: false, // default to false for backward compatibility
+		init: false,
+		mask: undefined,
+	}
+
+	/**
+	* @param {HTMLInputElement} input
+	* @param {Partial<Opts>} opts
+	* */
 	constructor(input, opts = {}) {
 		// satityze user's opts
 		for (const key of Object.keys(opts)) {
@@ -94,11 +103,7 @@ class Mask {
 
 		/** @type {Opts} */
 		this.opts = {
-			keyEvent: 'input',
-			triggerOnBlur: false,
-			triggerOnDelete: false, // default to false for backward compatibility
-			init: false,
-			mask: undefined,
+			...this.opts,
 			...opts,
 		}
 

--- a/src/mask.js
+++ b/src/mask.js
@@ -65,7 +65,7 @@ class Mask {
 			keyEvent: 'input',
 			triggerOnBlur: false,
 			init: false,
-			mask: '',
+			mask: undefined,
 			...opts,
 		}
 
@@ -82,12 +82,17 @@ class Mask {
 		this.events = new Set()
 		this.input = input
 
-		this.mask = input.dataset.mask ?? (
-			typeof this.opts.mask === 'function' ? this.opts.mask(input) : this.opts.mask
-		)
+		// evaluate initial mask
+		if (typeof this.opts.mask === 'function') {
+			this.mask = this.opts.mask(input)
+		} else if (typeof this.opts.mask === 'string') {
+			this.mask = this.opts.mask
+		} else {
+			this.mask = input.dataset.mask
+		}
 
 		// Check if has mask
-		if (this.mask.length === 0) {
+		if (!this.mask) {
 			throw new Error('The mask can not be empty')
 		}
 


### PR DESCRIPTION
### Pass a function to the `opts.mask`.

That function must return the mask string. It runs on each event, to update the mask **before** applying it.

The associated input is passed as it's first argument, so it's state can be used do calculate the mask'

When events trigger the mask, the second argument will contain that event too.
This of course doesn't happens on **initial** evaluation (if set `opts.init` true)

As can be seen on the update `/example/index.html`, it can now be use like:

```js
// <input data-mask="..." />
new Mask(input);

new Mask(input,
  mask: "(99) 9 9999-9999",
});

new Mask(input,
  mask: (inp, event)=>{
    if ( event.data === "#" ) return "...";
    return inp.value.lenght > 10 ? "..." : "...";
    ...
  }
});

```

### Track changes to `data-mask`

On the `data-mask` side, it can also be made dynamic, with an extra construction option `opts.dynamicDataMask`.

When this is set, a [MutationObserver](https://developer.mozilla.org/pt-BR/docs/Web/API/MutationObserver) is attached to the input, tracking changes to its `data-mask` prop.
When change is detected, the mask is updated and applied.


### extra stuff

Some other things were changed to better fit the behavior of dynamic mask

* Added option to enable update mask with backspace
* Order of preference of masks (potential backwards compatibility issue)
  * It was `data-mask` > `opt.mask`
  * Changed to `opt.mask()` > `opt.mask` > `data-mask`
  * To me at least, it makes sense even without dynamic mask,
  with "more effort" options supersedes weaker ones.
  As JS is really expected to overwrite HTML's behaviour
* `data-mask` dynamics are set separate from events
  * thus may lead to unexpected conflicts if both configured and happens to trigger together
  * function mask still runs on each event, so it will made changes to `data-mask` obsolete on next input
  * in the end is up to the developer using it, to stick to one way only 